### PR TITLE
In rbxlx spec, change example int to valid entry

### DIFF
--- a/formats/rbxlx.md
+++ b/formats/rbxlx.md
@@ -1102,7 +1102,7 @@ integer.
 ### Example
 
 ```xml
-<int name="Example">4294967295</int>
+<int name="Example">2147483647</int>
 ```
 
 ## int64


### PR DESCRIPTION
At the moment, the example for `int` used is the max value for an *unsigned* 32-bit integer. This isn't compatible with the actual datatype, as it is signed so we should change it. This PR does so.

Interestingly, loading a file with a property of this size doesn't overflow it as I was expecting and correctly places the property at the max 32-bit signed integer. The same is true for a negative number that's out of range.